### PR TITLE
fix: subscribe parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const UpdateWidgetSubscription = subscriptionWithClientId({
   outputFields: {
     widget: Widget,
   },
-  subscribe: ({ widgetId }) =>
+  subscribe: (source, { widgetId }) =>
     createSubscription(`widgets:${widgetId}:updated`),
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export interface SubscriptionConfig<TSource, TContext, TInput>
   inputFields?: Thunk<GraphQLInputFieldConfigMap>;
   outputFields?: Thunk<GraphQLFieldConfigMap<TSource, TContext>>;
   subscribe?: (
+    obj: TSource,
     input: TInput,
     context: TContext,
     info: GraphQLResolveInfo,
@@ -86,11 +87,11 @@ export function subscriptionWithClientId<
     subscribe:
       subscribe &&
       ((
-        _obj: TSource,
+        source: TSource,
         { input }: InputArgs<TInput>,
         context: TContext,
         info: GraphQLResolveInfo,
-      ) => subscribe(input, context, info)),
+      ) => subscribe(source, input, context, info)),
     resolve: (obj, { input }, context, info) =>
       Promise.resolve(getPayload(obj, input, context, info)).then(
         (payload) => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,13 +25,13 @@ export interface SubscriptionConfig<TSource, TContext, TInput>
   inputFields?: Thunk<GraphQLInputFieldConfigMap>;
   outputFields?: Thunk<GraphQLFieldConfigMap<TSource, TContext>>;
   subscribe?: (
-    obj: TSource,
+    source: TSource,
     input: TInput,
     context: TContext,
     info: GraphQLResolveInfo,
   ) => any;
   getPayload?: (
-    obj: TSource,
+    source: TSource,
     input: TInput,
     context: TContext,
     info: GraphQLResolveInfo,
@@ -42,8 +42,8 @@ function resolveThunk<T>(thunk: Thunk<T>): T {
   return thunk instanceof Function ? thunk() : thunk;
 }
 
-function defaultGetPayload<TSource>(obj: TSource) {
-  return obj;
+function defaultGetPayload<TSource>(source: TSource) {
+  return source;
 }
 
 export function subscriptionWithClientId<
@@ -92,8 +92,8 @@ export function subscriptionWithClientId<
         context: TContext,
         info: GraphQLResolveInfo,
       ) => subscribe(source, input, context, info)),
-    resolve: (obj, { input }, context, info) =>
-      Promise.resolve(getPayload(obj, input, context, info)).then(
+    resolve: (source, { input }, context, info) =>
+      Promise.resolve(getPayload(source, input, context, info)).then(
         (payload) => ({
           ...payload,
           clientSubscriptionId: input.clientSubscriptionId,

--- a/test/subscriptionWithClientId.test.ts
+++ b/test/subscriptionWithClientId.test.ts
@@ -138,7 +138,7 @@ describe('custom resolution', () => {
               value: { type: GraphQLString },
               arg: { type: GraphQLString },
             }),
-            async *subscribe({ arg }) {
+            async *subscribe(_, { arg }) {
               yield { value: `subscribed:${arg}` };
               yield { value: 'bar' };
             },


### PR DESCRIPTION
I am facing problem when use [withFilter](https://github.com/apollographql/graphql-subscriptions/blob/master/README.md#filters) cause the order of the parameters does not correspond and the `args` was being treated as `source`
https://github.com/apollographql/graphql-subscriptions/blob/82d0e4c324f7c7efefd141c925d24580f800037c/src/with-filter.ts#L11